### PR TITLE
Add typings for the day/month global constants

### DIFF
--- a/lib/common/OC.d.ts
+++ b/lib/common/OC.d.ts
@@ -88,4 +88,13 @@ declare namespace Nextcloud.Common {
         (size: Number, skipSmallSizes: boolean): string;
     }
 
+    interface DayMonthConstants {
+        firstDay: number
+        dayNames: String[]
+        dayNamesShort: String[]
+        dayNamesMin: String[]
+        monthNames: String[]
+        monthNamesShort: String[]
+    }
+
 }

--- a/lib/v16/OC.d.ts
+++ b/lib/v16/OC.d.ts
@@ -15,4 +15,8 @@ declare namespace Nextcloud.v16 {
 
     }
 
+    interface WindowWithGlobals extends Nextcloud.Common.DayMonthConstants, Window {
+
+    }
+
 }

--- a/lib/v17/OC.d.ts
+++ b/lib/v17/OC.d.ts
@@ -12,4 +12,8 @@ declare namespace Nextcloud.v17 {
 
     }
 
+    interface WindowWithGlobals extends Nextcloud.Common.DayMonthConstants, Window {
+
+    }
+
 }

--- a/lib/v18/OC.d.ts
+++ b/lib/v18/OC.d.ts
@@ -14,4 +14,8 @@ declare namespace Nextcloud.v18 {
 
     }
 
+    interface WindowWithGlobals extends Nextcloud.Common.DayMonthConstants, Window {
+
+    }
+
 }


### PR DESCRIPTION
Not as smooth to type as the functions. But I think this should work.

For https://github.com/nextcloud/nextcloud-l10n/pull/30