### PR TITLE
Add Nextcloud 21 and 22 typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.2.0 - 2021-06-28
+### Added
+- Nextcloud 21 typings
+- Nextcloud 22 typings
+
 ## 1.0.0 - 2020-08-31
 ### Added
 - Nextcloud 20 typings

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can use this package to verify your API usage is compatible with a range of 
 ```ts
 /// <reference types="@nextcloud/typings" />
 
-declare var OC: Nextcloud.v17.OC | Nextcloud.v18.OC | Nextcloud.v19.OC | Nextcloud.v20.OC;
+declare var OC: Nextcloud.v18.OC | Nextcloud.v19.OC | Nextcloud.v20.OC | Nextcloud.v21.OC;
 
 OC.L10N.translate("app", "text")
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can use this package to verify your API usage is compatible with a range of 
 ```ts
 /// <reference types="@nextcloud/typings" />
 
-declare var OC: Nextcloud.v18.OC | Nextcloud.v19.OC | Nextcloud.v20.OC | Nextcloud.v21.OC;
+declare var OC: Nextcloud.v19.OC | Nextcloud.v20.OC | Nextcloud.v21.OC | Nextcloud.v22.OC;
 
 OC.L10N.translate("app", "text")
 ```

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,3 +3,4 @@
 /// <reference path="v18/OC.d.ts" />
 /// <reference path="v19/OC.d.ts" />
 /// <reference path="v20/OC.d.ts" />
+/// <reference path="v21/OC.d.ts" />

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,3 +4,4 @@
 /// <reference path="v19/OC.d.ts" />
 /// <reference path="v20/OC.d.ts" />
 /// <reference path="v21/OC.d.ts" />
+/// <reference path="v22/OC.d.ts" />

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,1 @@
 /// <reference path="index.d.ts" />
-

--- a/lib/v21/OC.d.ts
+++ b/lib/v21/OC.d.ts
@@ -1,0 +1,15 @@
+declare namespace Nextcloud.v21 {
+
+    interface OC extends Nextcloud.v20.OC {
+
+    }
+
+    interface OCP extends Nextcloud.v20.OCP {
+
+    }
+
+    interface WindowWithGlobals extends Nextcloud.Common.DayMonthConstants, Window {
+
+    }
+
+}

--- a/lib/v22/OC.d.ts
+++ b/lib/v22/OC.d.ts
@@ -1,0 +1,15 @@
+declare namespace Nextcloud.v22 {
+
+    interface OC extends Nextcloud.v21.OC {
+
+    }
+
+    interface OCP extends Nextcloud.v21.OCP {
+
+    }
+
+    interface WindowWithGlobals extends Nextcloud.Common.DayMonthConstants, Window {
+
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/typings",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Nextcloud TypeScript typings",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -14,6 +14,16 @@
   ],
   "homepage": "https://github.com/nextcloud/nextcloud-typings#readme",
   "author": "Christoph Wurst",
+  "contributors": [
+    {
+      "name": "Christoph Wurst",
+      "email": "christoph@winzerhof-wurst.at"
+    },
+    {
+      "name": "Christopher Ng",
+      "email": "chrng8@gmail.com"
+    }
+  ],
   "license": "GPL-3.0-or-later",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Should be ready for v1.2.0 release :)

Note: No API changes found in v21 or v22 from `core/src/OC` and `core/src/OCP` source code.