### PR TITLE
Update v17: Add `debug` of type boolean to `OC`

### DIFF
--- a/lib/v17/OC.d.ts
+++ b/lib/v17/OC.d.ts
@@ -22,11 +22,13 @@ declare namespace Nextcloud.v17 {
     }
 
     interface OC extends Nextcloud.v16.OC {
-        appswebroots: any
-        config: any
-        coreApps: any
+        appswebroots: any;
+        config: any;
+        coreApps: any;
 
-        requestToken: string
+        debug: boolean;
+
+        requestToken: string;
 
         getCurrentUser(): Nextcloud.Common.CurrentUser;
         isUserAdmin(): boolean;


### PR DESCRIPTION
The `OC.debug` property was added with nextcloud v17, see https://github.com/nextcloud/server/commit/6095ef223562fdf8956663a90d58aa35593c68e0