### PR TITLE
Add Nextcloud 25 typings

### DIFF
--- a/lib/v25/OC.d.ts
+++ b/lib/v25/OC.d.ts
@@ -1,0 +1,20 @@
+declare namespace Nextcloud.v25 {
+
+    type FilePickerFilter = Nextcloud.v24.FilePickerFilter
+
+    interface FilePickerOptions extends Nextcloud.v24.FilePickerOptions {
+
+    }
+
+    interface OC extends Nextcloud.v24.OC {
+
+    }
+
+    interface OCP extends Nextcloud.v24.OCP {
+
+    }
+
+    interface WindowWithGlobals extends Nextcloud.Common.DayMonthConstants, Window {
+
+    }
+}


### PR DESCRIPTION
No front-end changes (https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_25.html#front-end-changes) so we can use the 24 API.