### PR TITLE
Added missing types for `OC.Plugins` available since NC8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## TBD
+### Fixed
+- Added missing `OC.Plugins` for all version
+
 ## 1.5.0 – 2022-11-03
 ### Added
 - Nextcloud 25 typings

--- a/lib/common/OC.d.ts
+++ b/lib/common/OC.d.ts
@@ -73,25 +73,68 @@ declare namespace Nextcloud.Common {
         All = 31,
     }
 
+    interface Plugin {
+        name: string;
+        attach?(targetObject: any, options?: Record<string, any>): void;
+        detach?(targetObject: any, options?: Record<string, any>): void;
+    }
+
+    interface Plugins {
+        /**
+         * Register plugin
+         *
+         * @param targetName app name / class name to hook into
+         * @param plugin plugin
+         */
+        register(targetName: string, plugin: Plugin): void;
+
+        /**
+         * Returns all plugin registered to the given target
+         * name / app name / class name.
+         *
+         * @param targetName app name / class name to hook into
+         * @return array of plugins
+         */
+        getPlugins(targetName: string): Array<Plugin>;
+
+        /**
+         * Call attach() on all plugins registered to the given target name.
+         *
+         * @param targetName app name / class name
+         * @param targetObject to be extended
+         * @param options
+         */
+        attach(targetName: string, targetObject: any, options?: Record<string, any>): void;
+
+        /**
+         * Call detach() on all plugins registered to the given target name.
+         *
+         * @param targetName app name / class name
+         * @param targetObject to be extended
+         * @param options
+         */
+        detach(targetName: string, targetObject: any, options?: Record<string, any>): void;
+    }
+
     interface FileInfo {
-         id: Nullable<number>
-         name: Nullable<string>
-         /**
-          * Absolute path of the containing directory
-          */
-         path: Nullable<string>
-         mimetype: Nullable<string>
-         /**
-          * URL which overrides the mime type icon
-          */
-         icon: Nullable<string>
-         permissions: Nullable<Permission>
-         mtime: Nullable<number>
-         etag: Nullable<string>
-         mountType: Nullable<'external-root' | 'shared' | 'shared-root'>
-         hasPreview: boolean
-         sharePermissions: Nullable<Permission>
-     }
+        id: Nullable<number>
+        name: Nullable<string>
+        /**
+         * Absolute path of the containing directory
+         */
+        path: Nullable<string>
+        mimetype: Nullable<string>
+        /**
+         * URL which overrides the mime type icon
+         */
+        icon: Nullable<string>
+        permissions: Nullable<Permission>
+        mtime: Nullable<number>
+        etag: Nullable<string>
+        mountType: Nullable<'external-root' | 'shared' | 'shared-root'>
+        hasPreview: boolean
+        sharePermissions: Nullable<Permission>
+    }
 
     interface OC {
         appswebroots: any
@@ -120,9 +163,10 @@ declare namespace Nextcloud.Common {
 
         dialogs: Dialogs;
         L10N: L10n;
+        Files: Files;
         Notifications: Notifications;
         PasswordConfirmation: PasswordConfirmation;
-        Files: Files;
+        Plugins: Plugins;
 
         webroot: string
     }


### PR DESCRIPTION
Fixes #126 

---
Added the missing types for the `OC.Plugins` API introduced with NC8 (see linked issue).