### PR TITLE
Fix exporting typings for NC25

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -7,3 +7,4 @@
 /// <reference path="v22/OC.d.ts" />
 /// <reference path="v23/OC.d.ts" />
 /// <reference path="v24/OC.d.ts" />
+/// <reference path="v25/OC.d.ts" />


### PR DESCRIPTION
Reference for NC25 is missing so `Nextcloud.v25` can not be used by projects.