### PR TITLE
chore(deps): Add renovate bot config

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 node_modules/
+/renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,40 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:base",
+		":semanticCommits"
+	],
+	"timezone": "Europe/Vienna",
+	"schedule": [
+		"before 5am on wednesday"
+	],
+	"labels": [
+		"dependencies"
+	],
+	"rangeStrategy": "bump",
+	"rebaseWhen": "conflicted",
+	"ignoreUnstable": false,
+	"baseBranches": [
+		"master"
+	],
+	"enabledManagers": [
+		"npm"
+	],
+	"ignoreDeps": [
+		"node",
+		"npm"
+	],
+	"packageRules": [
+		{
+			"matchUpdateTypes": ["minor", "patch"],
+			"matchCurrentVersion": "!/^0/",
+			"automerge": true,
+			"automergeType": "pr",
+			"platformAutomerge": true
+		},
+		{
+			"matchDepTypes": ["devDependencies"],
+			"extends": ["schedule:monthly"]
+		}
+	]
+}


### PR DESCRIPTION
* Weekly production dep update
* Monthly dev dep update
* Semantic commits

The current, weekly bumps for just anything drown me in notifications. I will enable the bot when this got merged, then disable Dependabot.